### PR TITLE
Make tracking ticks optional

### DIFF
--- a/lib/stopwatch.js
+++ b/lib/stopwatch.js
@@ -17,11 +17,11 @@ function Create() {
     };
 
     var self = {
-        start: function() {
+        start: function(trackTicks=true) {
             if(self.isRunning) return;
             _isRunning = true;
             self.reset();
-            updateTicks();
+            if(trackTicks) updateTicks();
         },
         stop: function() {
             if(!!!self.isRunning) return;

--- a/tests/stopwatch.js
+++ b/tests/stopwatch.js
@@ -30,6 +30,23 @@ module.exports["should return elapsed time/ticks not in zero when started"] = fu
 	test.done();
 };
 
+module.exports["should return 0 ticks when started if track ticks is false"] = function(test) {
+	test.expect(2);
+
+	var stopwatch = Stopwatch.create();
+
+	stopwatch.start(false);
+
+	sleep.sleep(2);
+
+	stopwatch.stop();
+
+	test.equal(stopwatch.isRunning, false);
+	test.equal(stopwatch.elapsedTicks, 0);
+
+	test.done();
+};
+
 module.exports["should return elapsed time/ticks not in zero when restarted"] = function(test) {
 	test.expect(3);
 


### PR DESCRIPTION
This allows tick tracking to be turned off. This is useful for anyone
using this library inside of a promise. process.nextTick(...) when in a loop can cause
a promise to never resolve.
